### PR TITLE
Grammatical Patch

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -161,7 +161,7 @@
         <div class="col-lg-5 col-lg-offset-1 col-sm-push-6 col-sm-6">
           <div class="clearfix"></div>
           <h2 class="section-heading">List images</h2>
-          <p class="lead">Get a list of images by using the endpoint <code>/list</code></p>
+          <p class="lead">Get a list of images by using the <code>/list</code> endpoint.</p>
           <pre><code>https://unsplash.it/list</code></pre>
         </div>
         <div class="col-lg-5 col-sm-pull-6 col-sm-6">


### PR DESCRIPTION
Hey!

I made a few small changes to `index.html`. Nothing big, I just added periods in places that did not have them. Most sections _did_ have periods, and it looked a bit odd in the few places that did not have them.

Most of them were like this:
![screen shot 2014-10-15 at 12 44 20 pm](https://cloud.githubusercontent.com/assets/1558388/4649486/0abf963e-548b-11e4-8bbf-727140d83e2b.png)

But then this section did not have a period:
![screen shot 2014-10-15 at 12 44 14 pm](https://cloud.githubusercontent.com/assets/1558388/4649500/21340b70-548b-11e4-9a04-8ab8e0123907.png)

And neither did this one:
![screen shot 2014-10-15 at 12 45 10 pm](https://cloud.githubusercontent.com/assets/1558388/4649505/30487894-548b-11e4-8a2d-df1bdd0df658.png)

I reorganized this sentence:

``` html
Get a list of images by using the endpoint <code>/list</code>
```

To this:

``` html
Get a list of images by using the <code>/list</code> endpoint.
```

And I added a period to the other section I showed an image of that was missing a period.
