### PR TITLE
Resolves issue #42

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -68,6 +68,9 @@ func (a *API) Router() http.Handler {
 	imageRouter.Handle("/id/{id}/{size:[0-9]+}{extension:(?:\\..*)?}", handler.Handler(a.imageRedirectHandler)).Methods("GET")
 	imageRouter.Handle("/id/{id}/{width:[0-9]+}/{height:[0-9]+}{extension:(?:\\..*)?}", handler.Handler(a.imageHandler)).Methods("GET")
 
+	// Describe image routes
+	imageRouter.Handle("/describe/{id}", handler.Handler(a.describeHandler)).Methods("GET")
+
 	// Query parameters:
 	// ?grayscale - Grayscale the image
 	// ?blur - Blur the image

--- a/api/image.go
+++ b/api/image.go
@@ -69,6 +69,7 @@ func (a *API) imageHandler(w http.ResponseWriter, r *http.Request) *handler.Erro
 	w.Header().Set("Content-Disposition", fmt.Sprintf("inline; filename=\"%s\"", buildFilename(imageID, p, width, height)))
 	w.Header().Set("Content-Type", "image/jpeg")
 	w.Header().Set("Cache-Control", "public, max-age=2592000") // Cache for a month
+	w.Header().Set("Content-Source-Url", databaseImage.URL)
 
 	// Return the image
 	w.Write(processedImage)

--- a/api/image.go
+++ b/api/image.go
@@ -69,7 +69,7 @@ func (a *API) imageHandler(w http.ResponseWriter, r *http.Request) *handler.Erro
 	w.Header().Set("Content-Disposition", fmt.Sprintf("inline; filename=\"%s\"", buildFilename(imageID, p, width, height)))
 	w.Header().Set("Content-Type", "image/jpeg")
 	w.Header().Set("Cache-Control", "public, max-age=2592000") // Cache for a month
-	w.Header().Set("Content-Source-Url", databaseImage.URL)
+	w.Header().Set("Picsum-Source-Url", databaseImage.URL)
 
 	// Return the image
 	w.Write(processedImage)


### PR DESCRIPTION
Resolves DMarby/picsum-photos#42

- Added new `/describe/{id}` route and handler to describe an image (metadata and download information) from its ID.
- Added `Picsum-Source-Url` response header to the image handler to return unsplash source URL.