### PR TITLE
Bump murmur3 to v1.1.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/spf13/cobra v0.0.3 // indirect
 	github.com/spf13/pflag v1.0.3 // indirect
 	github.com/stretchr/testify v1.3.0 // indirect
-	github.com/twmb/murmur3 v1.0.0
+	github.com/twmb/murmur3 v1.1.1
 	go.uber.org/atomic v1.3.2 // indirect
 	go.uber.org/multierr v1.1.0 // indirect
 	go.uber.org/zap v1.9.1

--- a/go.sum
+++ b/go.sum
@@ -57,8 +57,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-github.com/twmb/murmur3 v1.0.0 h1:MLMwMEQRKsu94uJnoveYjjHmcLwI3HNcWXP4LJuNe3I=
-github.com/twmb/murmur3 v1.0.0/go.mod h1:5Y5m8Y8WIyucaICVP+Aep5C8ydggjEuRQHDq1icoOYo=
+github.com/twmb/murmur3 v1.1.1 h1:jT/apbfn05lmNmvL+qrhXlLelBf8YJajjCWM+dB4FWg=
+github.com/twmb/murmur3 v1.1.1/go.mod h1:5Y5m8Y8WIyucaICVP+Aep5C8ydggjEuRQHDq1icoOYo=
 go.uber.org/atomic v1.3.2 h1:2Oa65PReHzfn29GpvgsYwloV9AVFHPDk8tYxt2c2tr4=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/multierr v1.1.0 h1:HoEmRHQPVSqub6w2z2d2EOVs2fjyFRGyofhKuyDq0QI=

--- a/internal/api/image.go
+++ b/internal/api/image.go
@@ -60,7 +60,7 @@ func (a *API) seedImageRedirectHandler(w http.ResponseWriter, r *http.Request) *
 	imageSeed := vars["seed"]
 
 	// Hash the input using murmur3
-	murmurHash := murmur3.Sum64([]byte(imageSeed))
+	murmurHash := murmur3.StringSum64(imageSeed)
 
 	// Get a random image by the hash
 	image, err := a.Database.GetRandomWithSeed(int64(murmurHash))


### PR DESCRIPTION
murmur3 included unsafe code; go1.14 has a -d=checkptr flag that checks
some uses of unsafe code. Turns out, the original usage of murmur3 was
unsafe due to alignment issues.

This does not affect the murmur128 assembly code because unaligned reads
on amd64 are safe (although slower, but we don't usually expect the hash
to have unaligned input).

This bumps the dep to pull in the fixes.