### PR TITLE
Adding TAO headers to expose timing resource info

### DIFF
--- a/internal/imageapi/image.go
+++ b/internal/imageapi/image.go
@@ -53,6 +53,7 @@ func (a *API) imageHandler(w http.ResponseWriter, r *http.Request) *handler.Erro
 	w.Header().Set("Content-Type", getContentType(p.Extension))
 	w.Header().Set("Cache-Control", "public, max-age=2592000") // Cache for a month
 	w.Header().Set("Picsum-ID", imageID)
+	w.Header().Set("Timing-Allow-Origin", "*") // Allow all origins to see timing resources
 
 	// Return the image
 	w.Write(processedImage)


### PR DESCRIPTION
This PR adds [Timing-Allow-Origin](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Timing-Allow-Origin) (TAO) header to images. This allows any origin to read resource timing values from the images. e.g.:

```javascript
performance.getEntriesByType('resource').filter(e => e.name.includes('picsum'))[0].transferSize // should be > 0
```